### PR TITLE
Upgrade python-telegram-bot to v22 (async)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,13 @@ dependencies = [
     "spotipy>=2.23.0",
     "dateparser>=1.1.1",
     "python-dotenv>=1.0.0",
-    "urllib3>=1.26,<2",  # python-telegram-bot v13 is incompatible with urllib3 v2
 ]
 readme = "README.md"
 requires-python = ">= 3.12"
 
 [project.optional-dependencies]
 telegram = [
-    "python-telegram-bot>=13.0,<20.0",
-    "setuptools<81",  # apscheduler (via python-telegram-bot) needs pkg_resources (removed in setuptools 82+)
+    "python-telegram-bot>=21.0",
 ]
 slack = [
     "slack-bolt>=1.18.0",
@@ -42,7 +40,7 @@ dev = [
     "pytest-mock>=3.11.1",
     "ty>=0.0.20",
     "httpx>=0.25.0",
-    "python-telegram-bot>=13.0,<20.0",
+    "python-telegram-bot>=21.0",
     "slack-bolt>=1.18.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "annotated-doc"
@@ -31,30 +35,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
-]
-
-[[package]]
-name = "apscheduler"
-version = "3.6.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytz" },
-    { name = "setuptools" },
-    { name = "six" },
-    { name = "tzlocal" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/89/3d/f65972547c5aa533276ada2bea3c2ef51bb4c4de55b67a66129c111b89ad/APScheduler-3.6.3.tar.gz", hash = "sha256:3bb5229eed6fbbdafc13ce962712ae66e175aa214c69bed35a06bffcf0c5e244", size = 96309, upload-time = "2019-11-05T07:51:50.394Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/34/9ef20ed473c4fd2c3df54ef77a27ae3fc7500b16b192add4720cab8b2c09/APScheduler-3.6.3-py2.py3-none-any.whl", hash = "sha256:e8b1ecdb4c7cb2818913f766d5898183c7cb8936680710a4d3a966e02262e526", size = 58881, upload-time = "2019-11-05T07:51:48.621Z" },
-]
-
-[[package]]
-name = "cachetools"
-version = "4.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/ba/619250fa6bc11ce6aa4de0604d45843090a53cd7d10d7253b89669313370/cachetools-4.2.2.tar.gz", hash = "sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff", size = 23682, upload-time = "2021-04-27T21:19:57.252Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/28/c4f5796c67ad06bb91d98d543a5e01805c1ff065e08871f78e52d2a331ad/cachetools-4.2.2-py3-none-any.whl", hash = "sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001", size = 11998, upload-time = "2021-04-27T21:19:55.559Z" },
 ]
 
 [[package]]
@@ -614,18 +594,15 @@ wheels = [
 
 [[package]]
 name = "python-telegram-bot"
-version = "13.15"
+version = "22.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apscheduler" },
-    { name = "cachetools" },
-    { name = "certifi" },
-    { name = "pytz" },
-    { name = "tornado" },
+    { name = "httpcore", marker = "python_full_version >= '3.14'" },
+    { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/bc/89cd44af162c3f5bf1bd50f4beb9f47353f027552e290899b55723746509/python-telegram-bot-13.15.tar.gz", hash = "sha256:b4047606b8081b62bbd6aa361f7ca1efe87fa8f1881ec9d932d35844bf57a154", size = 357762, upload-time = "2022-12-06T10:01:48.056Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/25/2258161b1069e66d6c39c0a602dbe57461d4767dc0012539970ea40bc9d6/python_telegram_bot-22.7.tar.gz", hash = "sha256:784b59ea3852fe4616ad63b4a0264c755637f5d725e87755ecdee28300febf61", size = 1516454, upload-time = "2026-03-16T09:36:03.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/db/29356a2f43052af470993fdf2083ca8bf28da4586da836aa609de2d86a06/python_telegram_bot-13.15-py3-none-any.whl", hash = "sha256:06780c258d3f2a3c6c79a7aeb45714f4cd1dd6275941b7dc4628bba64fddd465", size = 519214, upload-time = "2022-12-06T10:01:43.082Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f7/0e2f89dd62f45d46d4ea0d8aec5893ce5b37389638db010c117f46f11450/python_telegram_bot-22.7-py3-none-any.whl", hash = "sha256:d72eed532cf763758cd9331b57a6d790aff0bb4d37d8f4e92149436fe21c6475", size = 745365, upload-time = "2026-03-16T09:36:01.498Z" },
 ]
 
 [[package]]
@@ -834,15 +811,6 @@ wheels = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "80.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
-]
-
-[[package]]
 name = "simple-websocket"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -910,12 +878,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cde
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
-
-[[package]]
-name = "tornado"
-version = "6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/44/cc9590db23758ee7906d40cacff06c02a21c2a6166602e095a56cbf2f6f6/tornado-6.1.tar.gz", hash = "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791", size = 497359, upload-time = "2020-10-30T20:17:51.882Z" }
 
 [[package]]
 name = "ty"
@@ -1041,7 +1003,6 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-engineio" },
     { name = "spotipy" },
-    { name = "urllib3" },
     { name = "uvicorn" },
 ]
 
@@ -1051,7 +1012,6 @@ slack = [
 ]
 telegram = [
     { name = "python-telegram-bot" },
-    { name = "setuptools" },
 ]
 
 [package.dev-dependencies]
@@ -1076,11 +1036,9 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.4.2" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-engineio", specifier = ">=4.8.0" },
-    { name = "python-telegram-bot", marker = "extra == 'telegram'", specifier = ">=13.0,<20.0" },
-    { name = "setuptools", marker = "extra == 'telegram'", specifier = "<81" },
+    { name = "python-telegram-bot", marker = "extra == 'telegram'", specifier = ">=21.0" },
     { name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.18.0" },
     { name = "spotipy", specifier = ">=2.23.0" },
-    { name = "urllib3", specifier = ">=1.26,<2" },
     { name = "uvicorn", specifier = ">=0.23.2" },
 ]
 provides-extras = ["telegram", "slack"]
@@ -1092,7 +1050,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.21.1" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock", specifier = ">=3.11.1" },
-    { name = "python-telegram-bot", specifier = ">=13.0,<20.0" },
+    { name = "python-telegram-bot", specifier = ">=21.0" },
     { name = "ruff", specifier = ">=0.12" },
     { name = "slack-bolt", specifier = ">=1.18.0" },
     { name = "ty", specifier = ">=0.0.20" },

--- a/whats_on_fip/telegram/bot.py
+++ b/whats_on_fip/telegram/bot.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from dotenv import load_dotenv
-from telegram.ext import CommandHandler, Filters, MessageHandler, Updater
+from telegram.ext import Application, CommandHandler, MessageHandler, filters
 
 from whats_on_fip.telegram.handlers import get_feelgood, get_fiftyfifty, get_live, get_meuh
 
@@ -16,7 +16,7 @@ BOT_WEBHOOK_URL = os.getenv("BOT_WEBHOOK_URL", "https://fip-telegram-bot.dixneuf
 USE_POLLING = os.getenv("USE_POLLING") in ("True", "true", "1")
 
 
-def display_help(update, context):
+async def display_help(update, context):
     help_message = """
 This bot helps you share your love of FIP and other radios!
 
@@ -28,34 +28,35 @@ RadioMeuh - /meuh
 Radio5050 - /5050
 FeelGood - /feelgood /fg
     """
-    update.message.reply_text(help_message)
+    await update.message.reply_text(help_message)
 
 
 def main():
     if not BOT_TELEGRAM_TOKEN:
         raise RuntimeError("BOT_TELEGRAM_TOKEN environment variable is required")
 
-    updater = Updater(BOT_TELEGRAM_TOKEN, use_context=True)
+    application = Application.builder().token(BOT_TELEGRAM_TOKEN).build()
 
-    updater.dispatcher.add_handler(CommandHandler("whatsonFIP", get_live))
-    updater.dispatcher.add_handler(CommandHandler("live", get_live))
-    updater.dispatcher.add_handler(CommandHandler("meuh", get_meuh))
-    updater.dispatcher.add_handler(CommandHandler("5050", get_fiftyfifty))
-    updater.dispatcher.add_handler(CommandHandler("feelgood", get_feelgood))
-    updater.dispatcher.add_handler(CommandHandler("fg", get_feelgood))
-    updater.dispatcher.add_handler(CommandHandler("help", display_help))
-    updater.dispatcher.add_handler(MessageHandler(Filters.command, display_help))
+    application.add_handler(CommandHandler("whatsonFIP", get_live))
+    application.add_handler(CommandHandler("live", get_live))
+    application.add_handler(CommandHandler("meuh", get_meuh))
+    application.add_handler(CommandHandler("5050", get_fiftyfifty))
+    application.add_handler(CommandHandler("feelgood", get_feelgood))
+    application.add_handler(CommandHandler("fg", get_feelgood))
+    application.add_handler(CommandHandler("help", display_help))
+    application.add_handler(MessageHandler(filters.COMMAND, display_help))
 
     if USE_POLLING:
-        updater.start_polling()
-        logging.info("Start polling")
-        updater.idle()
+        application.run_polling()
     else:
         if not BOT_WEBHOOK_PATH:
             raise RuntimeError("BOT_WEBHOOK_PATH environment variable is required for webhook mode")
-        updater.start_webhook(listen="0.0.0.0", port=80, url_path=BOT_WEBHOOK_PATH)
-        updater.bot.set_webhook(f"{BOT_WEBHOOK_URL}/{BOT_WEBHOOK_PATH}")
-        updater.idle()
+        application.run_webhook(
+            listen="0.0.0.0",
+            port=80,
+            url_path=BOT_WEBHOOK_PATH,
+            webhook_url=f"{BOT_WEBHOOK_URL}/{BOT_WEBHOOK_PATH}",
+        )
 
 
 if __name__ == "__main__":

--- a/whats_on_fip/telegram/fmt.py
+++ b/whats_on_fip/telegram/fmt.py
@@ -1,4 +1,4 @@
-from telegram.utils.helpers import escape_markdown
+from telegram.helpers import escape_markdown
 
 from whats_on_fip.models import FIP_RADIO, Radio, Track
 

--- a/whats_on_fip/telegram/handlers.py
+++ b/whats_on_fip/telegram/handlers.py
@@ -1,8 +1,10 @@
 import logging
 from collections.abc import Callable
 
-from telegram import ParseMode
-from telegram.utils.helpers import escape_markdown
+from telegram import Update
+from telegram.constants import ParseMode
+from telegram.ext import ContextTypes
+from telegram.helpers import escape_markdown
 
 from whats_on_fip.models import (
     FEELGOOD_RADIO,
@@ -24,9 +26,16 @@ ERROR_MESSAGE = """Hum something went wrong... \nPing @dixneuf19 !"""
 TRACK_PROVIDERS = ["spotify", "youtube", "deezer", "itunes"]
 
 
-def _handle_radio(update, context, fetch_track: Callable[[], Track], radio: Radio):
-    update_message = update.message
-    logging.info(f"Got '{update_message.text}' from {update_message.from_user.username} in {update_message.chat.title}")
+async def _handle_radio(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, fetch_track: Callable[[], Track], radio: Radio
+):
+    message = update.message
+    if message is None:
+        return
+
+    logging.info(
+        f"Got '{message.text}' from {message.from_user.username if message.from_user else '?'} in {message.chat.title}"
+    )
     try:
         track = fetch_track()
 
@@ -36,10 +45,9 @@ def _handle_radio(update, context, fetch_track: Callable[[], Track], radio: Radi
         except Exception as e:
             logging.warning(f"Error enriching with Spotify: {e}")
 
-        logging.info(f"Found this song live: {str(track)}")
-        context.bot.send_message(
-            chat_id=update.effective_chat.id,
-            text=track_to_markdown(track, radio=radio),
+        logging.info(f"Found this song live: {track}")
+        await message.reply_text(
+            track_to_markdown(track, radio=radio),
             parse_mode=ParseMode.MARKDOWN_V2,
             disable_web_page_preview=True,
         )
@@ -49,45 +57,39 @@ def _handle_radio(update, context, fetch_track: Callable[[], Track], radio: Radi
             if provider in track.external_urls:
                 msg = f"Found this on {provider.title()} !\n\n{track.external_urls[provider]}"
                 logging.info(msg.replace("\n", " "))
-                context.bot.send_message(chat_id=update.effective_chat.id, text=msg)
+                await message.reply_text(msg)
                 return
 
         logging.info("No external urls found")
-        context.bot.send_message(
-            chat_id=update.effective_chat.id,
-            text="Not found on Spotify",
-            parse_mode=ParseMode.MARKDOWN_V2,
-        )
+        await message.reply_text("Not found on Spotify")
 
     except LiveUnavailableException:
         logging.info("No track information available right now")
-        context.bot.send_message(
-            chat_id=update.effective_chat.id,
-            text=escape_markdown("No live song information right now, is it ", version=2)
+        await message.reply_text(
+            escape_markdown("No live song information right now, is it ", version=2)
             + "_Club Jazzafip_"
             + escape_markdown(" ?", version=2),
             parse_mode=ParseMode.MARKDOWN_V2,
         )
     except Exception as e:
         logging.error(e)
-        context.bot.send_message(
-            chat_id=update.effective_chat.id,
-            text=escape_markdown(ERROR_MESSAGE, version=2),
+        await message.reply_text(
+            escape_markdown(ERROR_MESSAGE, version=2),
             parse_mode=ParseMode.MARKDOWN_V2,
         )
 
 
-def get_live(update, context):
-    _handle_radio(update, context, lambda: execute_live_query("FIP"), FIP_RADIO)
+async def get_live(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await _handle_radio(update, context, lambda: execute_live_query("FIP"), FIP_RADIO)
 
 
-def get_meuh(update, context):
-    _handle_radio(update, context, lambda: RadioMeuh().get_current_track(), MEUH_RADIO)
+async def get_meuh(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await _handle_radio(update, context, lambda: RadioMeuh().get_current_track(), MEUH_RADIO)
 
 
-def get_fiftyfifty(update, context):
-    _handle_radio(update, context, lambda: Radio5050().get_current_track(), FIFTYFIFTY_RADIO)
+async def get_fiftyfifty(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await _handle_radio(update, context, lambda: Radio5050().get_current_track(), FIFTYFIFTY_RADIO)
 
 
-def get_feelgood(update, context):
-    _handle_radio(update, context, lambda: RadioFeelGood().get_current_track(), FEELGOOD_RADIO)
+async def get_feelgood(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await _handle_radio(update, context, lambda: RadioFeelGood().get_current_track(), FEELGOOD_RADIO)


### PR DESCRIPTION
## Summary

python-telegram-bot v13 was incompatible with niquests — `urllib3-future` overwrites the `urllib3` namespace, breaking v13's vendored urllib3 fallback. Instead of patching around it, upgrade to v22:

- Async handlers with `Application` API (replaces `Updater`)
- Remove `urllib3<2` and `setuptools<81` pins (no longer needed)
- No more warnings about vendored urllib3 or deprecated pkg_resources

## Test plan

- [x] All 32 tests pass
- [x] Docker build succeeds
- [x] Container starts cleanly with `USE_POLLING=true` — `Application started`, no warnings
- [ ] Pod runs in cluster after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)