### PR TITLE
fix: drop pep440 versioning override and add recreateWhen for Python group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
       "description": "Group all Python runtime version updates into a single PR",
       "matchDepNames": ["python"],
       "groupName": "python runtime version",
-      "versioning": "pep440"
+      "recreateWhen": "always"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Remove `versioning: "pep440"` from the Python grouping rule — it breaks Docker tag matching for `python:3.12-slim` since `-slim` isn't valid pep440
- Add `recreateWhen: "always"` so closing a Renovate Python PR doesn't permanently ignore the update (PR #255 was closed and Renovate refused to recreate it)

Follow-up to #253 — these fixes were pushed to the branch after the PR was already merged.

## Test plan
- [ ] After merging, trigger a Renovate run and verify it creates a grouped PR with both Dockerfile (`python:3.12-slim → 3.14-slim`) and `requires-python` (`== 3.12.* → == 3.14.*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)